### PR TITLE
Db

### DIFF
--- a/server/dbRequests.js
+++ b/server/dbRequests.js
@@ -4,12 +4,11 @@ var env         =  process.env.NODE_ENV || 'development';
 var knex = require('knex')(config[env]); 
 
 
-exports.lookupWork = function(req){ //all these functions need to return promises (to allow calling .then in index.js), but
-  //don't yet. Currently results in errors. (JW)
+exports.lookupWork = function(req){
 	var title = req.title //or whatever that path ends up being
 	var type = req.type //same as above
 
-	    knex.select('*').from(type).where('title', title) //maybe change this to a LIKE to account for case errors or something?
+	 return knex.from(type).where('title', title) //maybe change this to a LIKE to account for case errors or something?
 	        .then(function(result){
 	          return result[0];
 	        })

--- a/server/dbRequests.js
+++ b/server/dbRequests.js
@@ -8,7 +8,7 @@ exports.lookupWork = function(req){
 	var title = req.title; //or whatever that path ends up being
 	var type = req.type; //same as above
 
-	return knex.from(type).where('title', title) //maybe change this to a LIKE to account for case errors or something?
+	return knex.from(type).where('title', title)
 	        .then(function(result){
             if (result.length === 0){
               throw new Error('No such work found');


### PR DESCRIPTION
-- lookupWork actually returns
-- some of the error throwing was happening in a catch that it would never actually hit because it returns an empty array
-- made sure variables were actually being declared and pulled out of the request body